### PR TITLE
#7 streamline query parameter naming all the way through the app

### DIFF
--- a/src/main/kotlin/minesweeper/controller/GameController.kt
+++ b/src/main/kotlin/minesweeper/controller/GameController.kt
@@ -15,15 +15,15 @@ class GameController(
 ) {
     @PostMapping("/games")
     fun createGame(
-            @RequestParam("size_horizontal") sizeHorizontal: Int,
-            @RequestParam("size_vertical") sizeVertical: Int,
+            @RequestParam("horizontal_size") horizontalSize: Int,
+            @RequestParam("vertical_size") verticalSize: Int,
             builder: UriComponentsBuilder
     ): ResponseEntity<*> {
-        validateInput(sizeHorizontal, sizeVertical)?.let { return it }
+        validateInput(horizontalSize, verticalSize)?.let { return it }
 
         val gameResponse = gameService.createGame(
-                sizeHorizontal,
-                sizeVertical)
+                horizontalSize,
+                verticalSize)
 
         return ResponseEntity
                 .created(builder.path("games/${gameResponse.id}")
@@ -32,15 +32,15 @@ class GameController(
                 .body(gameResponse)
     }
 
-    private fun validateInput(sizeHorizontal: Int,
-                              sizeVertical: Int): ResponseEntity<Problem>? {
+    private fun validateInput(horizontalSize: Int,
+                              verticalSize: Int): ResponseEntity<Problem>? {
         val errorMessages = mutableListOf<String>()
 
-        if (sizeHorizontal <= 0)
-            errorMessages += "size_horizontal must be greater than 0"
+        if (horizontalSize <= 0)
+            errorMessages += "horizontal_size must be greater than 0"
 
-        if (sizeVertical <= 0)
-            errorMessages += "size_horizontal must be greater than 0"
+        if (verticalSize <= 0)
+            errorMessages += "vertical_size must be greater than 0"
 
         return if (errorMessages.isEmpty()) null else buildProblem(errorMessages)
     }

--- a/src/main/kotlin/minesweeper/controller/model/BoardResponse.kt
+++ b/src/main/kotlin/minesweeper/controller/model/BoardResponse.kt
@@ -1,6 +1,6 @@
 package minesweeper.controller.model
 
-data class BoardResponse(val sizeHorizontal: Int,
-                         val sizeVertical: Int,
+data class BoardResponse(val horizontalSize: Int,
+                         val verticalSize: Int,
                          val board: List<List<CellResponse>>
 )

--- a/src/main/kotlin/minesweeper/controller/model/CellResponse.kt
+++ b/src/main/kotlin/minesweeper/controller/model/CellResponse.kt
@@ -1,5 +1,5 @@
 package minesweeper.controller.model
 
-data class CellResponse(val indexHorizontal: Int,
-                        val indexVertical: Int
+data class CellResponse(val horizontalIndex: Int,
+                        val verticalIndex: Int
 )

--- a/src/main/kotlin/minesweeper/repository/entity/BoardEntity.kt
+++ b/src/main/kotlin/minesweeper/repository/entity/BoardEntity.kt
@@ -1,5 +1,5 @@
 package minesweeper.repository.entity
 
-data class BoardEntity(val sizeHorizontal: Int,
-                       val sizeVertical: Int,
+data class BoardEntity(val horizontalSize: Int,
+                       val verticalSize: Int,
                        val board: List<List<CellEntity>>)

--- a/src/main/kotlin/minesweeper/repository/entity/CellEntity.kt
+++ b/src/main/kotlin/minesweeper/repository/entity/CellEntity.kt
@@ -1,4 +1,4 @@
 package minesweeper.repository.entity
 
-data class CellEntity(val indexHorizontal: Int,
-                      val indexVertical: Int)
+data class CellEntity(val horizontalIndex: Int,
+                      val verticalIndex: Int)

--- a/src/main/kotlin/minesweeper/service/GameFactory.kt
+++ b/src/main/kotlin/minesweeper/service/GameFactory.kt
@@ -7,19 +7,20 @@ import org.springframework.stereotype.Service
 
 @Service
 class GameFactory {
-    fun createGame(sizeHorizontal: Int,
-                   sizeVertical: Int): GameEntity {
-        val boardEntity = BoardEntity(sizeHorizontal = sizeHorizontal,
-                sizeVertical = sizeVertical,
-                board = List(sizeHorizontal) { horizontalIndex -> createColumn(horizontalIndex, sizeVertical) })
+    fun createGame(horizontalSize: Int,
+                   verticalSize: Int): GameEntity {
+        val boardEntity = BoardEntity(
+                horizontalSize = horizontalSize,
+                verticalSize = verticalSize,
+                board = List(horizontalSize) { horizontalIndex -> createColumn(horizontalIndex, verticalSize) })
 
         return GameEntity(board = boardEntity)
     }
 
-    private fun createColumn(horizontalIndex: Int, sizeVertical: Int): List<CellEntity> {
-        return List(sizeVertical) { verticalIndex ->
-            CellEntity(indexHorizontal = horizontalIndex,
-                    indexVertical = verticalIndex)
+    private fun createColumn(horizontalIndex: Int, verticalSize: Int): List<CellEntity> {
+        return List(verticalSize) { verticalIndex ->
+            CellEntity(horizontalIndex = horizontalIndex,
+                    verticalIndex = verticalIndex)
         }
     }
 }

--- a/src/main/kotlin/minesweeper/service/GameMapper.kt
+++ b/src/main/kotlin/minesweeper/service/GameMapper.kt
@@ -19,16 +19,16 @@ class GameMapper {
 
     private fun toBoardResponse(boardEntity: BoardEntity): BoardResponse {
         return BoardResponse(
-                sizeHorizontal = boardEntity.sizeHorizontal,
-                sizeVertical = boardEntity.sizeVertical,
+                horizontalSize = boardEntity.horizontalSize,
+                verticalSize = boardEntity.verticalSize,
                 board = boardEntity.board.map { outerArray -> outerArray.map { cell -> toCellResponse(cell) } }
         )
     }
 
     private fun toCellResponse(cellEntity: CellEntity): CellResponse {
         return CellResponse(
-                indexHorizontal = cellEntity.indexHorizontal,
-                indexVertical = cellEntity.indexVertical
+                horizontalIndex = cellEntity.horizontalIndex,
+                verticalIndex = cellEntity.verticalIndex
         )
     }
 }

--- a/src/main/kotlin/minesweeper/service/GameService.kt
+++ b/src/main/kotlin/minesweeper/service/GameService.kt
@@ -10,9 +10,9 @@ class GameService(
         private val gameMapper: GameMapper,
         private val gameRepository: GameRepository,
 ) {
-    fun createGame(sizeHorizonal: Int,
-                   sizeVertical: Int): GameResponse {
-        val gameEntity = gameFactory.createGame(sizeHorizonal, sizeVertical)
+    fun createGame(horizontalSize: Int,
+                   verticalSize: Int): GameResponse {
+        val gameEntity = gameFactory.createGame(horizontalSize, verticalSize)
         gameRepository.saveGame(gameEntity)
 
         return gameMapper.toGameResponse(gameEntity)

--- a/src/main/resources/minesweeper-api.yaml
+++ b/src/main/resources/minesweeper-api.yaml
@@ -11,16 +11,16 @@ paths:
       description: Creates a new minesweeper game
       parameters:
         - in: query
-          name: size_horizontal
+          name: horizontal_size
           schema:
             type: integer
           description: The size of the game board in the horizontal dimension. Must be a non-zero positive integer.
           required: true
         - in: query
-          name: size_vertical
+          name: vertical_size
           schema:
             type: integer
-          description: The size of the game board in the horizontal dimension. Must be a non-zero positive integer.
+          description: The size of the game board in the vertical dimension. Must be a non-zero positive integer.
           required: true
       responses:
         "201":
@@ -66,10 +66,10 @@ components:
     cell:
       type: object
       properties:
-        index_horizontal:
+        horizontal_index:
           type: integer
-        index_vertical:
+        vertical_index:
           type: integer
       required:
-        - index_horizontal
-        - index_vertical
+        - horizontal_index
+        - vertical_index

--- a/src/test/kotlin/minesweeper/controller/GameControllerTest.kt
+++ b/src/test/kotlin/minesweeper/controller/GameControllerTest.kt
@@ -29,8 +29,8 @@ class GameControllerTest(@Autowired val mockMvc: MockMvc) {
 
         mockMvc.perform(
                 request(HttpMethod.POST, "/games")
-                        .queryParam("size_horizontal", "10")
-                        .queryParam("size_vertical", "10")
+                        .queryParam("horizontal_size", "10")
+                        .queryParam("vertical_size", "10")
         )
                 .andExpect(MockMvcResultMatchers.status().isCreated)
                 .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
@@ -49,8 +49,8 @@ class GameControllerTest(@Autowired val mockMvc: MockMvc) {
     fun `create game invalid query parameters expect 400`() {
         mockMvc.perform(
                 request(HttpMethod.POST, "/games")
-                        .queryParam("size_horizontal", "-1")
-                        .queryParam("size_vertical", "-1")
+                        .queryParam("horizontal_size", "-1")
+                        .queryParam("vertical_size", "-1")
         )
                 .andExpect(MockMvcResultMatchers.status().isBadRequest)
     }

--- a/src/test/kotlin/minesweeper/service/GameFactoryTest.kt
+++ b/src/test/kotlin/minesweeper/service/GameFactoryTest.kt
@@ -9,19 +9,19 @@ class GameFactoryTest {
 
     @Test
     fun `test that board is generated correctly and each cell has the correct indices`() {
-        val sizeHorizontal = 10
-        val sizeVertical = 5
+        val horizontalSize = 10
+        val verticalSize = 5
 
-        val gameEntity = gameFactory.createGame(sizeHorizontal, sizeVertical)
+        val gameEntity = gameFactory.createGame(horizontalSize, verticalSize)
 
         assertNotNull(gameEntity.id)
-        assertEquals(Pair(sizeHorizontal, sizeVertical), Pair(gameEntity.board.sizeHorizontal, gameEntity.board.sizeVertical))
+        assertEquals(Pair(horizontalSize, verticalSize), Pair(gameEntity.board.horizontalSize, gameEntity.board.verticalSize))
         val board = gameEntity.board.board
 
         for (horizontalIndex in board.indices) {
             for (verticalIndex in board.first().indices) {
-                assertEquals(horizontalIndex, board[horizontalIndex][verticalIndex].indexHorizontal)
-                assertEquals(verticalIndex, board[horizontalIndex][verticalIndex].indexVertical)
+                assertEquals(horizontalIndex, board[horizontalIndex][verticalIndex].horizontalIndex)
+                assertEquals(verticalIndex, board[horizontalIndex][verticalIndex].verticalIndex)
             }
         }
     }

--- a/src/test/kotlin/minesweeper/service/GameMapperTest.kt
+++ b/src/test/kotlin/minesweeper/service/GameMapperTest.kt
@@ -17,16 +17,16 @@ class GameMapperTest {
 
         val boardResponse = gameResponse.board
 
-        assertEquals(gameEntity.board.sizeHorizontal, boardResponse.sizeHorizontal)
-        assertEquals(gameEntity.board.sizeVertical, boardResponse.sizeVertical)
+        assertEquals(gameEntity.board.horizontalSize, boardResponse.horizontalSize)
+        assertEquals(gameEntity.board.verticalSize, boardResponse.verticalSize)
 
         for (column in boardResponse.board.indices) {
             for (row in boardResponse.board[column].indices) {
                 val cellEntity = gameEntity.board.board[column][row]
                 val cellResponse = boardResponse.board[column][row]
 
-                assertEquals(cellEntity.indexHorizontal, cellResponse.indexHorizontal)
-                assertEquals(cellEntity.indexVertical, cellResponse.indexVertical)
+                assertEquals(cellEntity.horizontalIndex, cellResponse.horizontalIndex)
+                assertEquals(cellEntity.verticalIndex, cellResponse.verticalIndex)
             }
         }
     }

--- a/src/test/kotlin/minesweeper/service/GameServiceTest.kt
+++ b/src/test/kotlin/minesweeper/service/GameServiceTest.kt
@@ -27,7 +27,7 @@ class GameServiceTest {
 
     @Test
     fun `ensure that game is generated, saved, mapped`() {
-        val gameEntity = GameGenerator.generateGameEntity(10, 10, 10)
+        val gameEntity = GameGenerator.generateGameEntity(10, 10)
         every { gameFactory.createGame(10, 10) } returns gameEntity
         every { gameRepository.saveGame(gameEntity) } returns Unit
         every { gameMapper.toGameResponse(gameEntity) } returns GameGenerator.generateGameResponse()

--- a/src/test/kotlin/minesweeper/util/GameGenerator.kt
+++ b/src/test/kotlin/minesweeper/util/GameGenerator.kt
@@ -11,26 +11,24 @@ import kotlin.random.Random
 
 class GameGenerator {
     companion object {
-        fun generateGameEntity(sizeHorizontal: Int = Random.nextInt(1, 10),
-                               sizeVertical: Int = Random.nextInt(1, 10),
-                               mines: Int = Random.nextInt(1, sizeHorizontal)): GameEntity {
+        fun generateGameEntity(horizontalSize: Int = Random.nextInt(1, 10),
+                               verticalSize: Int = Random.nextInt(1, 10)): GameEntity {
             val boardEntity = BoardEntity(
-                    sizeHorizontal = sizeHorizontal,
-                    sizeVertical = sizeVertical,
-                    mines = mines,
-                    board = generateBoardEntityArray(sizeHorizontal, sizeVertical))
+                    horizontalSize = horizontalSize,
+                    verticalSize = verticalSize,
+                    board = generateBoardEntityArray(horizontalSize, verticalSize))
 
             return GameEntity(board = boardEntity)
         }
 
-        private fun generateBoardEntityArray(sizeHorizontal: Int,
-                                             sizeVertical: Int): List<List<CellEntity>> {
+        private fun generateBoardEntityArray(horizontalSize: Int,
+                                             verticalSize: Int): List<List<CellEntity>> {
             val board = mutableListOf<List<CellEntity>>()
 
-            for (columnIndex in 0..sizeHorizontal) {
+            for (columnIndex in 0..horizontalSize) {
                 val column = mutableListOf<CellEntity>()
 
-                for (rowIndex in 0..sizeVertical) {
+                for (rowIndex in 0..verticalSize) {
                     column.add(rowIndex, CellEntity(columnIndex, rowIndex))
                 }
 
@@ -39,28 +37,26 @@ class GameGenerator {
             return board.toList()
         }
 
-        fun generateGameResponse(sizeHorizontal: Int = Random.nextInt(1, 10),
-                                 sizeVertical: Int = Random.nextInt(1, 10),
-                                 mines: Int = Random.nextInt(1, 10)): GameResponse {
+        fun generateGameResponse(horizontalSize: Int = Random.nextInt(1, 10),
+                                 verticalSize: Int = Random.nextInt(1, 10)): GameResponse {
             val boardResponse = BoardResponse(
-                    sizeHorizontal = sizeHorizontal,
-                    sizeVertical = sizeVertical,
-                    mines = mines,
-                    board = generateBoardResponseArray(sizeHorizontal, sizeVertical))
+                    horizontalSize = horizontalSize,
+                    verticalSize = verticalSize,
+                    board = generateBoardResponseArray(horizontalSize, verticalSize))
 
             return GameResponse(
                     id = UUID.randomUUID(),
                     board = boardResponse)
         }
 
-        private fun generateBoardResponseArray(sizeHorizontal: Int,
-                                               sizeVertical: Int): List<List<CellResponse>> {
+        private fun generateBoardResponseArray(horizontalSize: Int,
+                                               verticalSize: Int): List<List<CellResponse>> {
             val board = mutableListOf<List<CellResponse>>()
 
-            for (columnIndex in 0..sizeHorizontal) {
+            for (columnIndex in 0..horizontalSize) {
                 val column = mutableListOf<CellResponse>()
 
-                for (rowIndex in 0..sizeVertical) {
+                for (rowIndex in 0..verticalSize) {
                     column.add(rowIndex, CellResponse(columnIndex, rowIndex))
                 }
 


### PR DESCRIPTION
Rename them all to consistent behavior: `(vertical|horizontal)(Size|Index)`